### PR TITLE
fixup! users/localentries: Allow more invalid entries for local groups

### DIFF
--- a/internal/users/localentries/localgroups.go
+++ b/internal/users/localentries/localgroups.go
@@ -190,7 +190,6 @@ func formatGroupEntries(ctx context.Context, groups []types.GroupEntry) string {
 	})
 
 	for _, entry := range GetUserDBLocked(ctx).localGroupInvalidEntries {
-		fmt.Println("Inserting", entry, "at", min(entry.lineNum, len(groupLines)-1))
 		groupLines = slices.Insert(groupLines, min(entry.lineNum, len(groupLines)-1), entry.line)
 	}
 

--- a/internal/users/localentries/lockedentries.go
+++ b/internal/users/localentries/lockedentries.go
@@ -62,6 +62,13 @@ var defaultOptions = options{
 // Option represents an optional function to override [UserDBLocked] default values.
 type Option func(*options)
 
+type invalidEntry struct {
+	// lineNum is the line number in the group file where the invalid line was found.
+	lineNum int
+	// line is the content of the invalid line.
+	line string
+}
+
 // UserDBLocked is a struct that holds the current users and groups while
 // ensuring that the system's user database is locked to prevent concurrent
 // modifications.
@@ -91,7 +98,7 @@ type UserDBLocked struct {
 	// localGroupEntries holds the current group entries.
 	localGroupEntries []types.GroupEntry
 	// localGroupInvalidEntries holds the current group invalid entries.
-	localGroupInvalidEntries []*string
+	localGroupInvalidEntries []invalidEntry
 
 	// options to set the local entries context.
 	options options


### PR DESCRIPTION
A bit cleaner approach than storing `nil` in the `localGroupInvalidEntries` slice for each valid line.